### PR TITLE
Feature: Add version label to be able to find version from image

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -50,6 +50,7 @@ jobs:
             _DOCKERHUB_IMAGE_TAGS+=",$DOCKERHUB_REPOSITORY:$_MAJOR_VERSION"
           fi
           echo "DOCKERHUB_IMAGE_TAGS=$_DOCKERHUB_IMAGE_TAGS" >> $GITHUB_ENV
+          echo "VERSION=$_VERSION"  >> $GITHUB_ENV
       - name: Set environment DOCKERHUB_IMAGE_PLATFORMS
         run: |
           _DOCKERHUB_IMAGE_PLATFORMS="linux/amd64,linux/arm64"
@@ -63,5 +64,6 @@ jobs:
         with:
           file: Dockerfile.${{ matrix.os }}
           tags: ${{ env.DOCKERHUB_IMAGE_TAGS }}
+          labels: org.opencontainers.image.version=${{ env.VERSION }}
           platforms: ${{ env.DOCKERHUB_IMAGE_PLATFORMS }}
           push: true


### PR DESCRIPTION
Add `org.opencontainers.image.version` label, from docker best practices:
- https://www.docker.com/blog/docker-best-practices-using-tags-and-labels-to-manage-docker-image-sprawl/

Example:

```
$ docker inspect ghcr.io/taxel/plextraktsync:latest | jq -r '.[].Config.Labels["org.opencontainers.image.version"]'
0.34.5
```